### PR TITLE
[Feature] run wordpress with mariadb by using Docker

### DIFF
--- a/05/docker-compose.yaml
+++ b/05/docker-compose.yaml
@@ -1,0 +1,30 @@
+services:
+  db:
+    image: mariadb:noble
+    volumes:
+      - db-data:/var/lib/mariadb
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: examplepassword
+      MARIADB_DATABASE: wordpress
+      MARIADB_USER: wordpress
+      MARIADB_PASSWORD: examplepassword
+
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:6.6.1
+    volumes:
+      - wordpress-data:/var/lib/wordpress:/var/www/html
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: examplepassword
+      WORDPRESS_DB_NAME: wordpress
+    ports:
+      - "8090:80"
+
+volumes:
+  db-data:
+  wordpress-data:


### PR DESCRIPTION
### 🍕 Why did I do that
- wordpressをmariadbをバックエンドにしてで動かすdocker-compose fileを書いて、経験を得るため
- 自分のjournalを作ることがゆめだったため　

<br>

### 🎄 What I did 
- Create the environment to build wordpress environment with mariadb by using docker
    - docker-compose.yaml (2つのコンテナを共存させる)
- Change A Folder Directory At All


<br>

### 🪡 How to run 
- You can just run
``` Dockerfile
# 1️⃣ build
docker-compose up -d
```

<br>

### 🙇🏼 Image
|Post View|Main View|
|----|----|
|<img width="1440" alt="Screenshot 2025-06-10 at 16 29 17" src="https://github.com/user-attachments/assets/ec361eda-ca8e-4023-a413-230ed30e0398" />|<img width="1440" alt="Screenshot 2025-06-10 at 16 30 01" src="https://github.com/user-attachments/assets/426d2609-32fb-4edb-9c49-267b60dc35b2" />|



<br>

### 💡 Credit
- [How to create wordpress environment with Docker](https://job-info.hateblo.jp/entry/2024/05/09/225138)
